### PR TITLE
chore: use full reference for reusable workflow

### DIFF
--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -12,4 +12,4 @@ jobs:
         uses: ahmadnassri/action-commit-lint@v1
   code-format:
     name: Code Format
-    uses: ./.github/workflows/code-format-verification.yml
+    uses: FromDoppler/.github/.github/workflows/code-format-verification.yml@main


### PR DESCRIPTION
See: https://docs.github.com/es/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#restrictions-and-behaviors-for-the-source-repository