### PR TITLE
Use gitling for conventional commits verification

### DIFF
--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -5,11 +5,23 @@ on:
 
 jobs:
   conventional-commits:
+    if: ${{ github.event_name == 'pull_request' }}
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - name: Conventional Commits Validator
-        uses: ahmadnassri/action-commit-lint@v1
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Install gitlint
+        shell: bash
+        run: |
+          python -m pip install gitlint
+      - name: Run gitlint
+        shell: bash
+        run: |
+          # Lint everything from the base to the latest
+          gitlint --commits "${{ github.event.pull_request.base.sha }}..HEAD"
   code-format:
     name: Code Format
     uses: FromDoppler/.github/.github/workflows/code-format-verification.yml@main


### PR DESCRIPTION
This change is for the use of the same tool already used in Jenkins CI
Allow configuring the linter with a `.gitlint` file in the repo to check

See:
- https://jorisroovers.com/gitlint/
- https://joe.gl/ombek/blog/pr-gitlint/