### PR TITLE
chore: configure settings of gitlint

### DIFF
--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -21,7 +21,10 @@ jobs:
         shell: bash
         run: |
           # Lint everything from the base to the latest
-          gitlint --commits "${{ github.event.pull_request.base.sha }}..HEAD"
+          gitlint --commits "${{ github.event.pull_request.base.sha }}..HEAD" \
+            -c general.contrib=contrib-title-conventional-commits \
+            -c general.ignore=body-is-missing,body-max-line-length \
+            -c title-max-length.line-length=100
   code-format:
     name: Code Format
     uses: FromDoppler/.github/.github/workflows/code-format-verification.yml@main


### PR DESCRIPTION
This avoids requiring the file `.gitlint` in the repositories, allowing inclusion it if some modification to this defaults setting for all org