### PR TITLE
feat: split dotnet ci and cd

### DIFF
--- a/.github/workflows/continuous-delivery-nuget.yml
+++ b/.github/workflows/continuous-delivery-nuget.yml
@@ -1,0 +1,49 @@
+name: Continuous Delivery
+
+on:
+  workflow_call:
+
+jobs:
+  github-packages:
+    name: Nuget to Github Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: "7.0.x"
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.10.2
+        with:
+          versionSpec: "5.x"
+      - name: Determine Version
+        id: version # step id used as reference for output values
+        uses: gittools/actions/gitversion/execute@v0.10.2
+      - name: Pack nuget
+        run: |
+          dotnet pack \
+            --output ./nugets \
+            --configuration Release \
+            -p:Version=${{ steps.version.outputs.nuGetVersion }}
+      - name: Check if generates nugets packages
+        id: has-nugets
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "./nugets/*.nupkg"
+      - name: Upload artifact
+        if: steps.has-nugets.outputs.files_exists == 'true'
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: nugets
+          path: ./nugets/*.nupkg
+      - name: Delivery nuget to Github Packages
+        if: steps.has-nugets.outputs.files_exists == 'true'
+        run: |
+          dotnet nuget push ./nugets/*.nupkg \
+            --skip-duplicate \
+            --api-key ${{ secrets.GITHUB_TOKEN }} \
+            --source 'https://nuget.pkg.github.com/${{ github.REPOSITORY_OWNER }}/index.json'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,11 +1,11 @@
-name: .NET
+name: Continuous Integration
 
 on:
   workflow_call:
 
 jobs:
-  continuous-delivery:
-    name: Continuous Integration and Delivery
+  format-build-test:
+    name: .NET format, build and test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -23,35 +23,3 @@ jobs:
       - name: Test with dotnet
         run: dotnet test --no-build --configuration Release --collect:"XPlat Code Coverage"
       - uses: codecov/codecov-action@v3.1.1
-
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.10.2
-        with:
-          versionSpec: "5.x"
-      - name: Determine Version
-        id: version # step id used as reference for output values
-        uses: gittools/actions/gitversion/execute@v0.10.2
-      - name: Pack nuget
-        run: |
-          dotnet pack \
-            --output ./nugets \
-            --configuration Release \
-            -p:Version=${{ steps.version.outputs.nuGetVersion }}
-      - name: Check if generates nugets packages
-        id: has-nugets
-        uses: andstor/file-existence-action@v1
-        with:
-          files: "./nugets/*.nupkg"
-      - name: Upload artifact
-        if: steps.has-nugets.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: nugets
-          path: ./nugets/*.nupkg
-      - name: Delivery nuget to Github Packages
-        if: steps.has-nugets.outputs.files_exists == 'true'
-        run: |
-          dotnet nuget push ./nugets/*.nupkg \
-            --skip-duplicate \
-            --api-key ${{ secrets.GITHUB_TOKEN }} \
-            --source 'https://nuget.pkg.github.com/${{ github.REPOSITORY_OWNER }}/index.json'

--- a/workflow-templates/fromdoppler.yml
+++ b/workflow-templates/fromdoppler.yml
@@ -15,6 +15,10 @@ jobs:
   dotnet:
     name: .NET
     uses: FromDoppler/.github/.github/workflows/dotnet.yml@main
+  nuget:
+    if: ${{ github.event_name == 'push' }}
+    name: Nuget
+    uses: FromDoppler/.github/.github/workflows/continuous-delivery-nuget.yml@main
   docker:
     if: ${{ github.event_name == 'push' }}
     name: Docker


### PR DESCRIPTION
This is to have two different pipelines for
- continuous integration for _.NET_
- continuous delivery of _Nuget_ packages

Thanks, @leoslopez for identifying this improvement opportunity