### PR TITLE
fix: upload codecov reports

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,4 +22,7 @@ jobs:
         run: dotnet build --configuration Release
       - name: Test with dotnet
         run: dotnet test --no-build --configuration Release --collect:"XPlat Code Coverage"
-      - uses: codecov/codecov-action@v3.1.4
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3.1.4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This PR is for add the secret token to allow upload codecov reports The token was configured globally for all public report in the organization Private repos must add the specific token generated for the repo