### PR TITLE
chore(dotnet): add github token env from secret

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,6 +7,8 @@ jobs:
   format-build-test:
     name: .NET format, build and test
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This allows configuring our _GitHub Packages Nuget_ registry using this environment variable instead of hardcoding the password in the `nuget.config` file