### PR TITLE
[DD-1324] allow read dotnet version to use from global.json file

### DIFF
--- a/.github/workflows/continuous-delivery-nuget.yml
+++ b/.github/workflows/continuous-delivery-nuget.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: "7.0.x"
+          global-json-file: "global.json"
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.10.2
         with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: "7.0.x"
+          global-json-file: "global.json"
       - name: Verify code format
         run: dotnet format --verify-no-changes
       - name: Build with dotnet


### PR DESCRIPTION
This allows to use of different dotnet versions per repository and upgrade versions more easily

See: https://github.com/actions/setup-dotnet/tree/v3/#using-the-global-json-file-input