### PR TITLE
chore: remove specific version of dotnet

### DIFF
--- a/.github/workflows/continuous-delivery-nuget.yml
+++ b/.github/workflows/continuous-delivery-nuget.yml
@@ -15,7 +15,6 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: "7.0.x"
           global-json-file: "global.json"
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.10.2

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: "7.0.x"
           global-json-file: "global.json"
       - name: Verify code format
         run: dotnet format --verify-no-changes


### PR DESCRIPTION
This force to indicate the version to use in the `global.json` file