### PR TITLE
[DOI-1651] install gitlint using pipx

### DIFF
--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -16,7 +16,8 @@ jobs:
       - name: Install gitlint
         shell: bash
         run: |
-          python -m pip install gitlint
+          apt install pipx
+          pipx install gitlint
       - name: Run gitlint
         shell: bash
         run: |


### PR DESCRIPTION
The conventions workflow it's failing when running `pip install`.