### PR TITLE
[DOI-2907] Allow to deploy INT image in QA environment for maven workflow

### DIFF
--- a/.github/workflows/continuous-delivery-maven-java17.yml
+++ b/.github/workflows/continuous-delivery-maven-java17.yml
@@ -288,7 +288,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - docker-hub
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/INT'
     environment:
       name: qa
     steps:


### PR DESCRIPTION
With this modification the QA environment will be able to deploy images with main or INT tags. Depending wich branch was last pushed.

The workflow caller hast to dispatch a run for the INT branch for this to work, I didn't check every repo but I believe thats already configured.